### PR TITLE
fix Check Results conditional render logic

### DIFF
--- a/src/card/CardHolder.js
+++ b/src/card/CardHolder.js
@@ -63,7 +63,7 @@ const CardHolder = () => {
         <Card key={card.id} card={card} />
       ))}
 
-      {isCardHolderEmpty && cards.length > 0 && (
+      {isCardHolderEmpty && Object.keys(cards).length > 0 && (
         <Button
           variant="contained"
           color="primary"


### PR DESCRIPTION
[1f69732](https://github.com/ocelots-rcn/EcoSort/commit/1f6973240f497cd784cbf6f6a70ecad2a4dfb544#diff-174d86d9a022fdc7182b433db01abe1de9da244f432cf031578cb30d17f0ec2e) added additional logic to the conditional rendering of the Check Results button. This caused a regression (the button never renders) because `cards` is an object. Changed the expression to correctly evaluate whether `cards` is empty.