### PR TITLE
Added hint to assessment after failed attempts (#13)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1792,7 +1792,6 @@
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
       "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2331,6 +2330,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -5305,12 +5313,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/bin/Bin.jsx
+++ b/src/bin/Bin.jsx
@@ -21,8 +21,11 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
+import Badge from '@mui/material/Badge';
 
 import CloseIcon from '@mui/icons-material/Close';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
 
 import { useDroppable } from '@dnd-kit/core';
 
@@ -33,11 +36,12 @@ import CardContent from '../card/CardContent.jsx';
 
 const Bin = ({ id, activeId }) => {
   const { translation } = useTranslationContext();
-  const { bins, cards, deleteBin } = useDataContext();
+  const { bins, cards, deleteBin, calculateBinStats, failedAttempts } = useDataContext();
 
   const bin = bins.find(bin => bin.id === id);
-
   const binCards = bin?.contents?.map(cardId => cards[cardId]) || [];
+  const { correct, incorrect } = calculateBinStats(id);
+  const showHints = failedAttempts >= 3;
 
   const { isOver, setNodeRef } = useDroppable({
     id,
@@ -72,21 +76,37 @@ const Bin = ({ id, activeId }) => {
       {/*Header container */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '8px' }}>
         <Typography variant="h2" sx={{ lineHeight: '1', fontWeight: '500', fontSize: '1.25rem', letterSpacing: '0.0075em', }}>{translation['group']} {id}</Typography>
-        <Tooltip title={translation.deleteBin}>
-          <IconButton
-            onClick={handleDeleteBin}
-            size="small"
-            sx={{
-              marginLeft: 'auto',
-              '&:hover': {
-                color: 'red',
-                backgroundColor: 'rgba(255, 0, 0, 0.2)',
-              },
-            }}
-          >
-            <CloseIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          {showHints && binCards.length > 0 && (
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <Tooltip title={`${correct} correct cards`}>
+                <Badge badgeContent={correct} color="success" sx={{ '& .MuiBadge-badge': { fontSize: '0.8rem' } }}>
+                  <CheckCircleIcon color="success" fontSize="small" />
+                </Badge>
+              </Tooltip>
+              <Tooltip title={`${incorrect} incorrect cards`}>
+                <Badge badgeContent={incorrect} color="error" sx={{ '& .MuiBadge-badge': { fontSize: '0.8rem' } }}>
+                  <ErrorIcon color="error" fontSize="small" />
+                </Badge>
+              </Tooltip>
+            </Box>
+          )}
+          <Tooltip title={translation.deleteBin}>
+            <IconButton
+              onClick={handleDeleteBin}
+              size="small"
+              sx={{
+                marginLeft: 'auto',
+                '&:hover': {
+                  color: 'red',
+                  backgroundColor: 'rgba(255, 0, 0, 0.2)',
+                },
+              }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
       </Box>
       {/* Card Container */}
       <Box

--- a/src/provider/DataProvider.jsx
+++ b/src/provider/DataProvider.jsx
@@ -2,7 +2,7 @@
 Copyright 2024 Caden Klopfenstein
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
-and associated documentation files (the “Software”), to deal in the Software without restriction,
+and associated documentation files (the "Software"), to deal in the Software without restriction,
 including without limitation the rights to use, copy, modify, merge, publish, distribute,
 sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
 is furnished to do so, subject to the following conditions:
@@ -10,7 +10,7 @@ is furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
 NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
@@ -93,6 +93,7 @@ const DataProvider = ({ children }) => {
   const [cards, setCards] = useState({});
   const [groupings, setGroupings] = useState({});
   const [currentGrouping, setCurrentGrouping] = useState('')
+  const [failedAttempts, setFailedAttempts] = useState(0);
 
   const [open, setOpen] = useState(false);
   const [correct, setCorrect] = useState(false);
@@ -189,10 +190,10 @@ const DataProvider = ({ children }) => {
     if (bins.length !== totalCategories) {
       setCorrect(false);
       setMessage(translation['assessmentGroupNumbers']);
+      setFailedAttempts(prev => prev + 1);
       setOpen(true);
       return;
     }
-
 
     if (assessmentFunction === 'categorical') {
       let isCorrect = true;
@@ -223,9 +224,11 @@ const DataProvider = ({ children }) => {
       if (isCorrect) {
         setCorrect(true);
         setMessage(translation['assessmentCorrect']);
+        setFailedAttempts(0); // Reset failed attempts on success
       } else {
         setCorrect(false);
         setMessage(translation['assessmentIncorrect']);
+        setFailedAttempts(prev => prev + 1);
       }
     } else {
       console.log("Implement your own assessment function");
@@ -262,8 +265,41 @@ const DataProvider = ({ children }) => {
     });
   };
 
+  // Calculate the number of correct and incorrect cards in a bin
+  const calculateBinStats = (binId) => {
+    const bin = bins.find(b => b.id === binId);
+    if (!bin || !bin.contents.length) return { correct: 0, incorrect: 0 };
+
+    const cardsInBin = bin.contents.map(cardId => cards[cardId]);
+    if (cardsInBin.length === 0) return { correct: 0, incorrect: 0 };
+
+    // Get the grouping value of the first card as reference
+    const firstCardGroupingValue = cardsInBin[0].grouping[currentGrouping];
+    
+    // Count correct and incorrect cards
+    const correct = cardsInBin.filter(card => card.grouping[currentGrouping] === firstCardGroupingValue).length;
+    const incorrect = cardsInBin.length - correct;
+
+    return { correct, incorrect };
+  };
+
   return (
-    <DataContext.Provider value={{ bins, setBins, cards, setCards, groupings, currentGrouping, setCurrentGrouping, createNewBin, checkGrouping, moveCard, deleteBin }}>
+    <DataContext.Provider value={{ 
+      bins, 
+      setBins, 
+      cards, 
+      setCards, 
+      groupings, 
+      currentGrouping, 
+      setCurrentGrouping, 
+      createNewBin, 
+      checkGrouping, 
+      moveCard, 
+      deleteBin, 
+      calculateBinStats, 
+      error,
+      failedAttempts 
+    }}>
       {children}
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>{translation['assessment']}</DialogTitle>


### PR DESCRIPTION
Implements the hint feature discussed in issue #13

Changes made:
- Track failed assessment attempts in DataProvider
- Show hint badges only after 3 failed attempts
- Display correct/incorrect counts with green/red badges
- Reset counter on successful grouping

Resolves #13